### PR TITLE
Fix nil pointer panic for next type block

### DIFF
--- a/cmd/categories.go
+++ b/cmd/categories.go
@@ -72,12 +72,13 @@ var categoriesCmd = &cobra.Command{
 		nextTypePattern := `(?mi)^\s*!Type:.*$`
 		nextTypeRe := regexp.MustCompile(nextTypePattern)
 		nextLoc := nextTypeRe.FindStringIndex(restOfText)
-		fmt.Printf("Next type found at:%d\n", nextLoc[1])
 		var endPos int
 		if nextLoc != nil {
+			fmt.Printf("Next type found at:%d\n", nextLoc[1])
 			// Found another Type line.
 			endPos = loc[1] + nextLoc[0]
 		} else {
+			fmt.Printf("No next type block found.\n")
 			// No other Type found
 			endPos = len(inputContent)
 		}

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -70,12 +70,13 @@ var tagsCmd = &cobra.Command{
 		nextTypePattern := `(?mi)^\s*!Type:.*$`
 		nextTypeRe := regexp.MustCompile(nextTypePattern)
 		nextLoc := nextTypeRe.FindStringIndex(restOfText)
-		fmt.Printf("Next type found at:%d\n", nextLoc[1])
 		var endPos int
 		if nextLoc != nil {
+			fmt.Printf("Next type found at:%d\n", nextLoc[1])
 			// Found another Type line.
 			endPos = loc[1] + nextLoc[0]
 		} else {
+			fmt.Printf("No next type block found.\n")
 			// No other Type found
 			endPos = len(inputContent)
 		}


### PR DESCRIPTION
## Summary
- prevent a panic when no next type block exists in categories and tags commands

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a28f96bac83229ac838142e6ccebc